### PR TITLE
chore: rename IQAICOM/IQAIcom to IQOfficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npx @iqai/mcp-near
 ### 🔧 Build from Source
 
 ```bash
-git clone https://github.com/IQAIcom/mcp-near.git
+git clone https://github.com/IQOfficial/mcp-near.git
 cd mcp-near
 pnpm install
 pnpm run build

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
 	"author": "IQAI",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/IQAIcom/mcp-near.git"
+		"url": "git+https://github.com/IQOfficial/mcp-near.git"
 	},
 	"license": "ISC",
-	"homepage": "https://github.com/IQAIcom/mcp-near#readme",
+	"homepage": "https://github.com/IQOfficial/mcp-near#readme",
 	"bugs": {
-		"url": "https://github.com/IQAIcom/mcp-near/issues"
+		"url": "https://github.com/IQOfficial/mcp-near/issues"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Renames `IQAICOM`, `IQAIcom`, and `iqaicom` references to `IQOfficial` / `iqofficial` (case-preserving) as part of the brand handle rename. Covers Twitter/X handles, GitHub URLs, Telegram links, package metadata, badges, and docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>